### PR TITLE
Support case sensitive file extensions. fixes #16

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -107,7 +107,7 @@ web:
             # Rules for specific URI patterns.
             rules:
                 # Allow access to common static files.
-                '\.(jpe?g|png|gif|svgz?|css|js|map|ico|bmp|eot|woff2?|otf|ttf)$':
+                '(?i)\.(jpe?g|png|gif|svgz?|css|js|map|ico|bmp|eot|woff2?|otf|ttf)$':
                     allow: true
                 '^/robots\.txt$':
                     allow: true


### PR DESCRIPTION
This change allows pass-thru support for folks who upload files with extension `.JPEG`, among others.