### PR TITLE
Update project name and description for packagist support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ Drupal is a flexible and extensible PHP-based CMS framework.
 
 Run through the Drupal installer as normal.  You will not be asked for database credentials as those are already provided.
 
+## Create a new project locally with Composer
+
+This Composer command will create a new Drupal 9 project locally from this template with the customizations you need to deploy your project to Platform.sh.
+
+```
+composer create-project platformsh/drupal-recommended-project
+```
+
 ## Customizations
 
 The following changes have been made relative to Drupal 9 "Recommended" project as it is downloaded from Drupal.org or Packagist.  If using this project as a reference for your own existing project, replicate the changes below to your project.

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "drupal/recommended-project",
-    "description": "Project template for Drupal 9 projects with a relocated document root",
+    "name": "platformsh/drupal-recommended-project",
+    "description": "This template builds Drupal 9 for Platform.sh based the \"Drupal Recommended\" Composer project.",
     "type": "project",
     "license": "GPL-2.0-or-later",
     "homepage": "https://www.drupal.org/project/drupal",


### PR DESCRIPTION
This PR updates the template to allow it to be used with packagist for the Composer create project command. 

For others to use this, you'll need to create a release on Github and submit the template to packagist.

Feel free to use your own discretion with these additions to write them or name them as you like. I added what looks reasonable starting point..