### PR TITLE
:memo: Change cron to new syntax

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -145,7 +145,8 @@ crons:
     # Run Drupal's cron tasks every 19 minutes.
     drupal:
         spec: '*/19 * * * *'
-        cmd: 'cd web ; drush core-cron'
+        commands:
+            start: 'cd web ; drush core-cron'
 
 source:
   operations:


### PR DESCRIPTION
From the new changes (see [blog post](https://platform.sh/blog/2022/reel-in-activities-announcing-cancellable-activities-and-crons/))