### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ In general, the steps are as follows:
     web_environment:
     - PLATFORMSH_CLI_TOKEN=abcdeyourtoken`
     ```
+1. Update [`.ddev/config.yaml`](.ddev/config.yaml) changing the [`name:`](.ddev/config.yaml#L1) property to match the name of your project.
 1. Run `ddev restart`.
 1. Get your project ID with `platform project:info`. If you have not already connected your local repo with the project (as is the case with a source integration, by default), you can run `platform project:list` to locate the project ID, and `platform project:set-remote PROJECT_ID` to configure Platform.sh locally.
 1. Update the `.ddev/providers/platform.yaml` file for your current setup:


### PR DESCRIPTION
Updates ddev instructions to include updating name of ddev project.

## Description
If you create more than one project based off this template, if you do not change the name of the project in `.ddev/config.yaml` then when attempting to start ddev, you'll receive the error 
```
Failed to get project(s): a project (web container) in exited state already exists for api that was created at /Users/gilzow/projects/demos/d9-dcon
```
## Related Issue
#105 

### Please drop a link to the issue here: 
#105 

## Motivation and Context
ddev fails to start.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the contribution guide
- [x] I have created an issue following the issue guide
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
