### PR TITLE
Sync the ddev mariadb version with platform

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -10,7 +10,7 @@ additional_hostnames: []
 additional_fqdns: []
 database:
   type: mariadb
-  version: "10.3"
+  version: "10.4"
 nfs_mount_enabled: false
 mutagen_enabled: false
 use_dns_when_possible: true


### PR DESCRIPTION
I noticed when using this template that I got a slightly older version of mariadb in my local ddev than my platform project has. This change should sync the two in the template.

## Description
Update mariadb to be the same version as the one in .platform.app.yaml

