### PR TITLE
closes #114  #115

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -81,10 +81,11 @@ hooks:
     deploy: |
         set -e
         php ./drush/platformsh_generate_drush_yml.php
-        cd web
-        drush -y cache-rebuild
-        drush -y updatedb
-        drush -y config-import
+      # if drupal is installed, will call the following drush commands:
+      #   - `cache-rebuild`
+      #   - `updatedb`
+      #   - and if config files are present, `config-import`
+      ./drush/platformsh_deploy_drupal.sh
 
 # The configuration of app when it is exposed to the web.
 web:
@@ -153,4 +154,4 @@ source:
     auto-update:
       command: |
         curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/setup.sh | { bash /dev/fd/3 sop-autoupdate; } 3<&0
-    
+

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -81,11 +81,11 @@ hooks:
     deploy: |
         set -e
         php ./drush/platformsh_generate_drush_yml.php
-      # if drupal is installed, will call the following drush commands:
-      #   - `cache-rebuild`
-      #   - `updatedb`
-      #   - and if config files are present, `config-import`
-      ./drush/platformsh_deploy_drupal.sh
+        # if drupal is installed, will call the following drush commands:
+        #   - `cache-rebuild`
+        #   - `updatedb`
+        #   - and if config files are present, `config-import`
+        ./drush/platformsh_deploy_drupal.sh
 
 # The configuration of app when it is exposed to the web.
 web:

--- a/drush/platformsh_deploy_drupal.sh
+++ b/drush/platformsh_deploy_drupal.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# We don't want to run drush commands if drupal isn't installed.
+# Similarly, we don't want to attempt to run config-import if there aren't any config files to import
+# @todo expand further to pass --uri for all sites, with an eye towards multisite
+#
+
+
+if [ -n "$(drush status bootstrap)" ]; then
+  drush -y cache-rebuild
+  drush -y updatedb
+  if [ -n "$(ls $(drush php:eval "echo realpath(Drupal\Core\Site\Settings::get('config_sync_directory'));")/*.yml 2>/dev/null)" ]; then
+    drush -y config-import
+  else
+    echo "No config to import. Skipping."
+  fi
+else
+  echo "Drupal not installed. Skipping standard Drupal deploy steps"
+fi


### PR DESCRIPTION
## Description
Moves drush deploy commands to dedicated shell script
checks to make sure drupal is installed, and if so, calls `cache-rebuild`, `updatedb`, and if config files are present, `config-import`

This is stage 1 of the script. Next stage will be to see if the Drupal instance has been configured to be something other than `default` and if so, pass `--uri` with the correct value to all drush commands. Along the same way, we should expand the script to support drupal multisite.

## Related Issues
#114 & #115 

## Motivation and Context
Lines [81-87 in .platform.app.yaml](https://github.com/platformsh-templates/drupal9/blob/master/.platform.app.yaml#L81-L87) contains a series of drush commands in the deploy hook. In existing site, these commands make sense and are beneficial. However, in a brand new deploy of a drupal project, Drupal is not installed and these commands trigger an error in the log. This can cause confusion for new users as it appears the deploy failed or encountered issues.

Similarly, [Line 87 of .platform.app.yaml](https://github.com/platformsh-templates/drupal9/blob/master/.platform.app.yaml#L87) includes a drush config-import command in the deploy hook. If the project doesn't actively use configuration management, then the config import will fail with an error

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
 Go over all the following list, and put an `x` in all the boxes that apply. If you're unsure about what any of these mean, don't hesitate to ask. We're here to help!

- [X] I have read the contribution guide
- [X] I have created an issue following the issue guide
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
