### PR TITLE
DDEV config: PHP 8.1 is required for most of what happens here; use mariadb:10.4

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,9 +1,9 @@
 type: drupal9
 docroot: web
-php_version: "8.0"
+php_version: "8.1"
 database:
   type: mariadb
-  version: "10.3"
+  version: "10.4"
 nodejs_version: "16"
 
 # Key features of ddev's config.yaml:


### PR DESCRIPTION
## Description

PHP 8.1 is required for this to work; update config.yaml to use it.

## Related Issue

* #138

### Please drop a link to the issue here:

* https://github.com/platformsh-templates/drupal9/issues/138

