### PR TITLE
[Enhancement] update last.updated via workflow, but with a better branch name

### DIFF
--- a/.github/workflows/last-updated.yaml
+++ b/.github/workflows/last-updated.yaml
@@ -1,0 +1,31 @@
+name: Update last.updated
+on:
+  push:
+    branches:
+      - main
+      - master
+jobs:
+  update-last-updated-file:
+    name: "Updates the last.updated file with the current date"
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'platformsh-templates' && github.event.commits[0].author.name != 'GitHub Action' }}
+    steps:
+      - name: 'get repo'
+        id: prepautopr
+        uses: actions/checkout@v3
+        with:
+          token: ${{secrets.TEMPLATES_GITHUB_TOKEN }}
+      - name: 'set git config'
+        shell: bash
+        run: |
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+      - name: 'update last.updated'
+        id: last-updated
+        shell: bash
+        run: |
+          date > ./.platform/last.updated
+          git add ./.platform/last.updated
+          git commit -m "auto-updates version, post merge"
+          git push origin ${{ github.event.repository.default_branch }}
+

--- a/.github/workflows/last-updated.yaml
+++ b/.github/workflows/last-updated.yaml
@@ -4,6 +4,11 @@ on:
     branches:
       - main
       - master
+
+env:
+  DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+  GH_TOKEN: ${{ secrets.TEMPLATES_GITHUB_TOKEN }}
+
 jobs:
   update-last-updated-file:
     name: "Updates the last.updated file with the current date"
@@ -11,15 +16,35 @@ jobs:
     if: ${{ github.repository_owner == 'platformsh-templates' && github.event.commits[0].author.name != 'GitHub Action' }}
     steps:
       - name: 'get repo'
-        id: prepautopr
+        id: get-repo
         uses: actions/checkout@v3
         with:
           token: ${{secrets.TEMPLATES_GITHUB_TOKEN }}
+
       - name: 'set git config'
         shell: bash
         run: |
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"
+
+      - name: 'check for enforce admins'
+        id: 'check-for-enforce'
+        shell: bash
+        run: |
+          enforceAdmins=$(gh api "/repos/${GITHUB_REPOSITORY}/branches/${DEFAULT_BRANCH}/protection/enforce_admins" --jq '.enabled')
+          echo "::notice is enforce admins enabled? ${enforceAdmins}"
+          echo "enforce_admin=${enforceAdmins}" >> $GITHUB_OUTPUT
+
+      - name: 'disable enforce admins'
+        id: 'disable-force-admins'
+        if: ${{ 'true' == steps.check-for-enforce.outputs.enforce_admin }}
+        shell: bash
+        run: |
+          echo "::notice::Enforce Admins is enabled. Temporarily disabling..."
+          gh api --method DELETE "/repos/${GITHUB_REPOSITORY}/branches/${DEFAULT_BRANCH}/protection/enforce_admins" --silent \
+               && echo "::notice::Enforce admins disabled" \
+               || echo "::error::Disabling enforce admin failed"
+
       - name: 'update last.updated'
         id: last-updated
         shell: bash
@@ -27,5 +52,15 @@ jobs:
           date > ./.platform/last.updated
           git add ./.platform/last.updated
           git commit -m "auto-updates version, post merge"
-          git push origin ${{ github.event.repository.default_branch }}
+          git push origin "${DEFAULT_BRANCH}"
 
+      - name: "Re-enable enforce admins"
+        id: re-enable-enforce-admin
+        if: ${{ 'true' == steps.check-for-enforce.outputs.enforce_admin }}
+        shell: bash
+        run: |
+          gh api --method POST \
+          -H "Accept: application/vnd.github+json" \
+          "/repos/${GITHUB_REPOSITORY}/branches/${DEFAULT_BRANCH}/protection/enforce_admins" --silent \
+          && echo "::notice::Successfully re-enabled enforce admin" \
+          || echo "::error::Re-enabling enforce admins failed."


### PR DESCRIPTION
## Description
adds workflow to update the ./.platform/last.updated file with the current Date for better tracking of what version of the template a customer is using

## Related Issue
#141 

### Please drop a link to the issue here:
#141 

## Motivation and Context
Customers creating projects from these templates get a copy of this repository. After that, there is no connection back to this template. Since these templates are constantly being improved, in attempting to assist customers using our templates, it would be helpful to know what version of the template they started from. The simplest, least intrusive method is to add a date stamp to a file so we can compare that date with merges. from there we'll have a solid idea of what they're working with. 

## How Has This Been Tested?
https://github.com/gilzow/inject-post-merge/actions

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] I have read the contribution guide
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.