### PR TITLE
call bash to execute script

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -86,7 +86,7 @@ hooks:
         #   - `updatedb`
         #   - and if config files are present, `config-import`
         cd web
-        $PLATFORM_APP_DIR/drush/platformsh_deploy_drupal.sh
+        bash $PLATFORM_APP_DIR/drush/platformsh_deploy_drupal.sh
 
 # The configuration of app when it is exposed to the web.
 web:


### PR DESCRIPTION
## Description
calls bash and hands it the script file instead of assuming the script is executable. Closes #169

## Related Issue
#169 Also see https://github.com/platformsh/template-builder/pull/830 

## Motivation and Context
#169 

## How Has This Been Tested?
Already implemented in D10; this template was missed.


## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have read the contribution guide
- [X] I have created an issue following the issue guide
- [X] My code follows the code style of this project.
